### PR TITLE
Change `TXS_TABLE` from using `mempool...` to `canonical_beacon_block...` tables

### DIFF
--- a/plot-generator/src/clickhouse.py
+++ b/plot-generator/src/clickhouse.py
@@ -4,7 +4,7 @@ import os
 BLOB_SIDECAR_TABLE = 'beacon_api_eth_v1_events_blob_sidecar'
 BLOCK_TABLE = 'beacon_api_eth_v2_beacon_block'
 BLOCK_CANON_TABLE = 'canonical_beacon_block'
-TXS_TABLE = 'mempool_transaction'
+TXS_TABLE = 'canonical_beacon_block_execution_transaction_local'
 
 
 def clickhouse_client_init() -> Client:

--- a/plot-generator/src/plots/area/blob_size_used_per_blob.py
+++ b/plot-generator/src/plots/area/blob_size_used_per_blob.py
@@ -12,12 +12,12 @@ def blob_size_used_per_blob_create(client):
     day_limit = 30
 
     query = f'''
-               SELECT
-                    toDate(event_date_time) AS day,
+                SELECT
+                    toDate(slot_start_date_time) AS day,
                     AVG((blob_sidecars_size-blob_sidecars_empty_size) / blob_sidecars_size * 100)  AS used_blob_size
                 FROM {TXS_TABLE}
-                WHERE meta_network_name = 'mainnet'
-                AND event_date_time > now() - interval {day_limit} day
+                WHERE meta_network_name = 'mainnet' AND type = 3
+                AND slot_start_date_time > now() - interval 30 day
                 GROUP BY day
             '''
 

--- a/plot-generator/src/plots/area/blob_size_used_per_blob.py
+++ b/plot-generator/src/plots/area/blob_size_used_per_blob.py
@@ -17,7 +17,7 @@ def blob_size_used_per_blob_create(client):
                     AVG((blob_sidecars_size-blob_sidecars_empty_size) / blob_sidecars_size * 100)  AS used_blob_size
                 FROM {TXS_TABLE}
                 WHERE meta_network_name = 'mainnet' AND type = 3
-                AND slot_start_date_time > now() - interval 30 day
+                AND slot_start_date_time > now() - interval {day_limit} day
                 GROUP BY day
             '''
 


### PR DESCRIPTION
# Changes
- Slightly modified the query for the Blob Size Used per Blob plot.
- Use canonical_beacon_block for transactions instead of mempool.